### PR TITLE
Ensure callback still happens when conversion encounters error

### DIFF
--- a/src/main/java/com/idrsolutions/microservice/BaseServlet.java
+++ b/src/main/java/com/idrsolutions/microservice/BaseServlet.java
@@ -456,8 +456,8 @@ public abstract class BaseServlet extends HttpServlet {
         convertQueue.submit(() -> {
             try {
                 convert(individual, params, inputFile, outputDir, contextUrl);
-                handleCallback(individual, params);
             } finally {
+                handleCallback(individual, params);
                 individual.setAlive(false);
             }
         });


### PR DESCRIPTION
Move callback call from the try section to the finally so that if an exception occurs it will still run.