### PR TITLE
Allow zip files to be created without the parent directory at the base level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.idrsolutions</groupId>
     <artifactId>base-microservice-example</artifactId>
     <packaging>jar</packaging>
-    <version>8.0.3</version>
+    <version>8.1.0</version>
     <name>IDRsolutions Base Microservice Example</name>
     <description>Provides the shared classes used by IDRsolutions microservice examples.</description>
     <url>https://github.com/idrsolutions/base-microservice-example</url>

--- a/src/main/java/com/idrsolutions/microservice/utils/ZipHelper.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/ZipHelper.java
@@ -34,6 +34,7 @@ public class ZipHelper {
 
     /**
      * Zip a folder and all its contents to the destination zip.
+     * Includes a parent directory within the zip file with the name of the source folder.
      *
      * @param srcFolder the source folder to zip
      * @param destZipFile the name of the zip file to zip to
@@ -43,6 +44,14 @@ public class ZipHelper {
         zipFolder(srcFolder, destZipFile, true);
     }
 
+    /**
+     * Zip a folder and all its contents to the destination zip.
+     *
+     * @param srcFolder the source folder to zip
+     * @param destZipFile the name of the zip file to zip to
+     * @param createParentDirectoryInZip whether to include a base-level parent directory with the name of source folder
+     * @throws IOException if there is a problem writing or reading the file
+     */
     public static void zipFolder(final String srcFolder, final String destZipFile, final boolean createParentDirectoryInZip) throws IOException {
         final File zipOut = new File(destZipFile);
         if (!zipOut.exists()) {
@@ -63,8 +72,8 @@ public class ZipHelper {
      * given then calls 
      * {@link ZipHelper#addFolderToZip(String, String, ZipOutputStream) }
      *
-     * @param path the path to the file to zip
-     * @param srcFile the name of the file to zip
+     * @param path the current location within the zip file (must include a trailing slash unless the value is empty)
+     * @param srcFile the path of the file to zip file
      * @param zip the zip stream to write to
      * @throws IOException if there is a problem while reading the file
      */
@@ -86,11 +95,10 @@ public class ZipHelper {
     }
 
     /**
-     * Zips the given folder (including all sub files and writes to
-     * ZipOutputStream.
+     * Zips the given folder (including all sub files and writes to ZipOutputStream.
      *
-     * @param path The path to the folder to recursively zip
-     * @param srcFolder the name of the folder to zip
+     * @param path the current location within the zip file
+     * @param srcFolder the path of the folder to add to the zip file
      * @param zip the zip stream to write to
      * @throws IOException if there is a problem while reading the file
      */

--- a/src/main/java/com/idrsolutions/microservice/utils/ZipHelper.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/ZipHelper.java
@@ -97,7 +97,7 @@ public class ZipHelper {
     /**
      * Zips the given folder (including all sub files and writes to ZipOutputStream.
      *
-     * @param path the current location within the zip file
+     * @param path the current location within the zip file (must include a trailing slash unless the value is empty)
      * @param srcFolder the path of the folder to add to the zip file
      * @param zip the zip stream to write to
      * @throws IOException if there is a problem while reading the file

--- a/src/main/java/com/idrsolutions/microservice/utils/ZipHelper.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/ZipHelper.java
@@ -34,7 +34,7 @@ public class ZipHelper {
 
     /**
      * Zip a folder and all its contents to the destination zip.
-     * Includes a parent directory within the zip file with the name of the source folder.
+     * Includes a parent directory within the zip file with the same name as the source folder.
      *
      * @param srcFolder the source folder to zip
      * @param destZipFile the name of the zip file to zip to
@@ -49,7 +49,7 @@ public class ZipHelper {
      *
      * @param srcFolder the source folder to zip
      * @param destZipFile the name of the zip file to zip to
-     * @param createParentDirectoryInZip whether to include a base-level parent directory with the name of source folder
+     * @param createParentDirectoryInZip whether to include a parent directory within the zip file with the same name as the source folder
      * @throws IOException if there is a problem writing or reading the file
      */
     public static void zipFolder(final String srcFolder, final String destZipFile, final boolean createParentDirectoryInZip) throws IOException {

--- a/src/main/java/com/idrsolutions/microservice/utils/ZipHelper.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/ZipHelper.java
@@ -40,6 +40,10 @@ public class ZipHelper {
      * @throws IOException if there is a problem writing or reading the file
      */
     public static void zipFolder(final String srcFolder, final String destZipFile) throws IOException {
+        zipFolder(srcFolder, destZipFile, true);
+    }
+
+    public static void zipFolder(final String srcFolder, final String destZipFile, final boolean createParentDirectoryInZip) throws IOException {
         final File zipOut = new File(destZipFile);
         if (!zipOut.exists()) {
             zipOut.createNewFile();
@@ -48,7 +52,7 @@ public class ZipHelper {
         try (
                 final FileOutputStream fileWriter = new FileOutputStream(zipOut);
                 final ZipOutputStream zip = new ZipOutputStream(fileWriter)) {
-            addFolderToZip("", srcFolder, zip);
+            addFolderToZip(createParentDirectoryInZip ? new File(srcFolder).getName() + '/' : "", srcFolder, zip);
             zip.flush();
             fileWriter.flush();
         }
@@ -66,14 +70,14 @@ public class ZipHelper {
      */
     private static void addFileToZip(final String path, final String srcFile, final ZipOutputStream zip) throws IOException {
 
-        final File folder = new File(srcFile);
-        if (folder.isDirectory()) {
-            addFolderToZip(path, srcFile, zip);
+        final File file = new File(srcFile);
+        if (file.isDirectory()) {
+            addFolderToZip(path + file.getName() + '/', srcFile, zip);
         } else {
             try (final FileInputStream in = new FileInputStream(srcFile)) {
                 final byte[] buf = new byte[1024];
                 int len;
-                zip.putNextEntry(new ZipEntry(path + "/" + folder.getName()));
+                zip.putNextEntry(new ZipEntry(path + file.getName()));
                 while ((len = in.read(buf)) > 0) {
                     zip.write(buf, 0, len);
                 }
@@ -95,11 +99,7 @@ public class ZipHelper {
         final String[] fileList = folder.list();
         if (fileList != null) {
             for (final String fileName : fileList) {
-                if (path.equals("")) {
-                    addFileToZip(folder.getName(), srcFolder + "/" + fileName, zip);
-                } else {
-                    addFileToZip(path + "/" + folder.getName(), srcFolder + "/" + fileName, zip);
-                }
+                addFileToZip(path, srcFolder + '/' + fileName, zip);
             }
         }
     }


### PR DESCRIPTION
Before
```
example.zip
+-- example
    +-- 1.html
    +-- 2.html
    +-- etc
```

After (optionally)
```
example.zip
+-- 1.html
+-- 2.html
+-- etc
```

This is backwards compatible & the default behavior remains the same.

More info: https://3.basecamp.com/3537281/buckets/2186053/todos/3927260018#__recording_3986097522