### PR TITLE
Replaced IMAP with a database implemented with sqlite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>javax.json</artifactId>
             <version>1.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.36.0.3</version>
+        </dependency>
     </dependencies>
     
     <build>

--- a/src/main/java/com/idrsolutions/microservice/BaseServlet.java
+++ b/src/main/java/com/idrsolutions/microservice/BaseServlet.java
@@ -232,7 +232,7 @@ public abstract class BaseServlet extends HttpServlet {
     protected void doPost(final HttpServletRequest request, final HttpServletResponse response) {
 
         // imap.entrySet().removeIf(entry -> entry.getValue().getTimestamp() < new Date().getTime() - individualTTL);
-        database.cleanOldEntries();
+        database.cleanOldEntries(individualTTL);
 
         final String inputType = request.getParameter("input");
         if (inputType == null) {

--- a/src/main/java/com/idrsolutions/microservice/Individual.java
+++ b/src/main/java/com/idrsolutions/microservice/Individual.java
@@ -20,18 +20,21 @@
  */
 package com.idrsolutions.microservice;
 
-import java.util.Date;
-import java.util.Map;
+import com.idrsolutions.microservice.utils.DBHandler;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import javax.json.Json;
-import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Represents a file conversion request to the server. Allows storage of UUID's
  * for identification of clients which are requesting file conversions.
  */
 public class Individual {
+    DBHandler database = BaseServlet.database;
 
     private final String uuid;
     private boolean isAlive = true;
@@ -42,7 +45,8 @@ public class Individual {
     private Object customData;
 
     private Map<String, String> settings;
-    private JsonObjectBuilder customValues = Json.createObjectBuilder();
+    private Map<String, String> customValues = new HashMap<>();
+    // private JsonObjectBuilder customValues = Json.createObjectBuilder();
 
     /**
      * Create individual with a specific UUID.
@@ -53,6 +57,17 @@ public class Individual {
         this.uuid = uuid;
         timestamp = new Date().getTime();
         state = "queued";
+
+        database.putIndividual(this);
+    }
+
+    public Individual(String uuid, boolean isAlive, long timestamp, String state, String errorCode, String errorMessage) {
+        this.uuid = uuid;
+        this.isAlive = isAlive;
+        this.timestamp = timestamp;
+        this.state = state;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
     }
 
     /**
@@ -67,6 +82,8 @@ public class Individual {
         this.state = "error";
         this.errorCode = String.valueOf(errorCode);
         this.errorMessage = errorMessage == null ? "" : errorMessage;
+
+        database.executeUpdate();
     }
 
     /**
@@ -82,23 +99,17 @@ public class Individual {
             json.add("error", errorMessage);
         }
 
-        getCustomValues().forEach((s, jsonValue) -> json.add(s, jsonValue));
+        getCustomValues().forEach(json::add);
 
         return json.build().toString();
     }
 
-    /**
-     * Get the immutable JsonObject from customValues, while ensuring customValues
-     * keeps mutability
-     *
-     * @return an immutable JsonObject of customValues
-     */
-    private JsonObject getCustomValues() {
-        final JsonObject jsonObj = customValues.build();
-        customValues = Json.createObjectBuilder();
-        jsonObj.forEach((s, jsonValue) -> customValues.add(s, jsonValue));
+    public Map<String, String> getCustomValues() {
+        return customValues;
+    }
 
-        return jsonObj;
+    public void setCustomValues(Map<String, String> customValues) {
+        this.customValues = customValues;
     }
 
     /**
@@ -109,7 +120,7 @@ public class Individual {
      * @param value the value mapped to the key
      */
     public void setValue(final String key, final String value) {
-        customValues.add(key, value);
+        customValues.put(key, value);
     }
 
     /**
@@ -120,7 +131,8 @@ public class Individual {
      * @param value the value mapped to the key
      */
     public void setValue(final String key, final boolean value) {
-        customValues.add(key, value);
+        // customValues.add(key, value);
+        throw new NotImplementedException();
     }
 
     /**
@@ -131,7 +143,8 @@ public class Individual {
      * @param value the value mapped to the key
      */
     public void setValue(final String key, final int value) {
-        customValues.add(key, value);
+        // customValues.add(key, value);
+        throw new NotImplementedException();
     }
 
     /**

--- a/src/main/java/com/idrsolutions/microservice/Individual.java
+++ b/src/main/java/com/idrsolutions/microservice/Individual.java
@@ -60,6 +60,18 @@ public class Individual {
         database.putIndividual(this);
     }
 
+    /**
+     * Create an individual, setting all of it's fields
+     * This is intended for use by the database, as this method does not create an entry inside the database
+     * @param uuid the uuid to identify this individual
+     * @param isAlive the alive state of the individual
+     * @param timestamp the creation timestamp of the indivual
+     * @param state the state of the individual
+     * @param errorCode the error code of the Individual
+     * @param errorMessage the error message of the Individual
+     * @param settings the conversion settings
+     * @param customValues the custom values
+     */
     public Individual(String uuid, boolean isAlive, long timestamp, String state, String errorCode, String errorMessage, HashMap<String, String> settings, HashMap<String, String> customValues) {
         this.uuid = uuid;
         this.isAlive = isAlive;
@@ -109,7 +121,15 @@ public class Individual {
         return json.build().toString();
     }
 
-    StringBuilder getMassInsertString(String table, Map<String, String> values) {
+    /**
+     * Gets an SQL string that will insert all the given values into the given table
+     * Returns null if the Values map is empty
+     *
+     * @param table The table for the INSERT operation to operate on
+     * @param values The values to be inserted into the table
+     * @return The complete sql string, or null if the value map is empty
+     */
+    public static String getMassInsertString(String table, Map<String, String> values) {
         if (values.isEmpty()) return null;
         StringBuilder sqlString = new StringBuilder("INSERT INTO " + table + " VALUES");
 
@@ -123,13 +143,17 @@ public class Individual {
             sqlString.append(" (\"").append(uuid).append("\", \"").append(key).append("\", \"").append(values.get(key)).append("\")");
         }
 
-        return sqlString;
+        return sqlString.toString();
     }
 
     public Map<String, String> getCustomValues() {
         return customValues;
     }
 
+    /**
+     * Store a HashMap containing custom values
+     * @param customValues The custom values
+     */
     public void setCustomValues(Map<String, String> customValues) {
         this.customValues = customValues;
 
@@ -139,7 +163,7 @@ public class Individual {
         );
 
         if (!customValues.isEmpty()) {
-            database.executeUpdate(getMassInsertString("customValues", customValues).toString());
+            database.executeUpdate(getMassInsertString("customValues", customValues));
         }
     }
 
@@ -294,7 +318,7 @@ public class Individual {
         );
 
         if (!settings.isEmpty()) {
-            database.executeUpdate(getMassInsertString("settings", this.settings).toString());
+            database.executeUpdate(getMassInsertString("settings", this.settings));
         }
     }
 

--- a/src/main/java/com/idrsolutions/microservice/utils/DBHandler.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/DBHandler.java
@@ -1,0 +1,109 @@
+
+package com.idrsolutions.microservice.utils;
+
+import com.idrsolutions.microservice.BaseServlet;
+import com.idrsolutions.microservice.Individual;
+
+import java.sql.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.UUID;
+
+public class DBHandler {
+    Connection connection;
+    Statement statement;
+
+    public DBHandler() {
+        try {
+            Class.forName("org.sqlite.JDBC");
+            connection = DriverManager.getConnection("jdbc:sqlite:database.db");
+            statement = connection.createStatement();
+            setupDatabase();
+        } catch (SQLException | ClassNotFoundException err) {
+            err.printStackTrace();
+            System.exit(-1);
+        }
+    }
+
+    public void shutdown() {
+        try {
+            statement.close();
+            connection.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void setupDatabase() throws SQLException {
+        // Clear Tables
+        statement.executeUpdate("DROP TABLE IF EXISTS settings");
+        statement.executeUpdate("DROP TABLE IF EXISTS conversions");
+
+        // Create Tables
+        statement.executeUpdate("CREATE TABLE conversions (" +
+                                        "uuid VARCHAR(36), " +
+                                        "isAlive BOOLEAN, " +
+                                        "theTime UNSIGNED BIGINT(255), " +
+                                        "state VARCHAR(10), " +
+                                        "errorCode VARCHAR(5), " +
+                                        "errorMessage VARCHAR(255), " +
+                                        "previewURL TEXT," +
+                                        "downloadURL TEXT," +
+                                        "PRIMARY KEY (uuid)" +
+                                ")");
+        statement.executeUpdate("CREATE TABLE settings (" +
+                                        "uuid VARCHAR(36), " +
+                                        "key VARCHAR(70), " +
+                                        "value VARCHAR(255), " +
+                                        "PRIMARY KEY (uuid, key), " +
+                                        "FOREIGN KEY (uuid) REFERENCES conversions(uuid) ON DELETE CASCADE" +
+                                ")");
+
+    }
+
+    public Individual getIndividual(String id) throws SQLException {
+        ResultSet theIndividual = statement.executeQuery("SELECT * FROM conversions WHERE uuid=\"" + id + "\";");
+        Individual individual = new Individual(theIndividual.getString("uuid"),
+                theIndividual.getBoolean("isAlive"),
+                theIndividual.getLong("theTime"),
+                theIndividual.getString("state"),
+                theIndividual.getString("errorCode"),
+                theIndividual.getString("errorMessage")
+        );
+
+        ResultSet theSettings = statement.executeQuery("SELECT key, value FROM settings WHERE uuid=\"" + id + "\";");
+        HashMap<String, String> settings = new HashMap<>();
+
+        while (theSettings.next()) {
+            settings.put(theSettings.getString("key"), theSettings.getString("value"));
+        }
+
+        individual.setSettings(settings);
+
+        return individual;
+    }
+
+    public void executeUpdate(String sql) {
+        try {
+            statement.executeUpdate(sql);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void putIndividual(Individual individual) {
+        try {
+            statement.executeUpdate("INSERT INTO conversions (uuid, isAlive, theTime, state, errorCode, errorMessage) VALUES (" + individual.getUuid() + ", " + individual.isAlive() + ", " + individual.getTimestamp() + ", " + individual.getState() + ", " + individual.getErrorCode() + ", " + individual.getErrorMessage() + ", " + ")");
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void cleanOldEntries() {
+        try {
+            statement.executeUpdate("DELETE FROM conversions WHERE theTime < " + (new Date().getTime() - BaseServlet.individualTTL));
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
The IMAP Structure has been completely stripped out in favour of a database connection established in `utils.DBHandler`.


Implementation notes
 * The database is currently cleared and re-setup every time the microservice is launched
 * Some changes have been made to `Individual` to make it more compatible, mainly custom values has been swapped out for a `HashMap<String, String>`, with Boolean and integer entries being converted to strings (and I've also deprecated the methods that insert Booleans and integers in favour of the string one).
 * `Individual#customData` has not been included in the database, meaning between handing the `Individual` to the database and retrieving it the value will be lost. Leon has proposed changing it from an `Object` type to a `Map<String, String>`, however this will incur changes to the microservices that use it, so I believe it requires some discussion.