### PR TITLE
Update ByteBuffer usage 

### DIFF
--- a/src/main/java/com/idrsolutions/microservice/utils/DefaultFileServlet.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/DefaultFileServlet.java
@@ -111,14 +111,19 @@ import static java.util.logging.Level.FINE;
  * <li><a href="https://stackoverflow.com/q/13588149/157882">How to stream audio/video files such as MP3, MP4, AVI, etc using a Servlet</a>
  * <li><a href="https://stackoverflow.com/a/29991447/157882">Abstract template for a static resource servlet</a>
  * </ul>
- *
+ * <p>
  * This class is a derivative of the OmniFaces FileServlet class.
- *
+ * <p>
  * Modifications made in this version:
- * 1. Inlined imported omnifaces dependencies to make this class fully self-contained
- * 2. Changed package and class name so as not to conflict if used in other projects that include their own version
- * 3. Added a new abstract method {@link #getBasePath()} which defines the location on disk from which to serve files
- * 4. Added a default implementation of {@link #getFile(HttpServletRequest)} which calls {@link #getBasePath()}
+ * <ol>
+ * <li>Inlined imported omnifaces dependencies to make this class fully self-contained
+ * <li>Changed package and class name so as not to conflict if used in other projects that include their own version
+ * <li>Added a new abstract method {@link #getBasePath()} which defines the location on disk from which to serve files
+ * <li>Added a default implementation of {@link #getFile(HttpServletRequest)} which calls {@link #getBasePath()}
+ * <li>Updated ByteBuffer usage in {@link #stream(InputStream, OutputStream)} and {@link #stream(File, OutputStream, long, long)}
+ * to ensure code functions on Java 8 when compiled with a Java version higher than 9
+ * <li>Moved WritableByteChannel into a try-with-resources statement for {@link #stream(File, OutputStream, long, long)}
+ * </ol>
  *
  * @author Bauke Scholtz
  * @since 2.2

--- a/src/main/java/com/idrsolutions/microservice/utils/DefaultFileServlet.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/DefaultFileServlet.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.net.URLEncoder;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
@@ -686,9 +687,9 @@ public abstract class DefaultFileServlet extends HttpServlet {
             long size = 0;
 
             while (inputChannel.read(buffer) != -1) {
-                buffer.flip();
+                ((Buffer) buffer).flip();
                 size += outputChannel.write(buffer);
-                buffer.clear();
+                ((Buffer) buffer).clear();
             }
         }
     }
@@ -710,16 +711,16 @@ public abstract class DefaultFileServlet extends HttpServlet {
             return;
         }
 
-        try (FileChannel fileChannel = (FileChannel) Files.newByteChannel(file.toPath(), StandardOpenOption.READ)) {
-            WritableByteChannel outputChannel = Channels.newChannel(output);
+        try (FileChannel fileChannel = (FileChannel) Files.newByteChannel(file.toPath(), StandardOpenOption.READ);
+             WritableByteChannel outputChannel = Channels.newChannel(output)) {
             ByteBuffer buffer = ByteBuffer.allocateDirect(DEFAULT_STREAM_BUFFER_SIZE);
             long size = 0;
 
             while (fileChannel.read(buffer, start + size) != -1) {
-                buffer.flip();
+                ((Buffer) buffer).flip();
 
                 if (size + buffer.limit() > length) {
-                    buffer.limit((int) (length - size));
+                    ((Buffer) buffer).limit((int) (length - size));
                 }
 
                 size += outputChannel.write(buffer);
@@ -728,7 +729,7 @@ public abstract class DefaultFileServlet extends HttpServlet {
                     break;
                 }
 
-                buffer.clear();
+                ((Buffer) buffer).clear();
             }
         }
     }


### PR DESCRIPTION
so code functions on Java 8 when compiled with a Java version higher than 9. This is done by casting the object into a Buffer before calling the methods. 

When reviewing both stream methods, I saw that WritableByteChannel was in the try-with-resources statement for one (see [line 684](https://github.com/idrsolutions/base-microservice-example/blob/bug/fix-bytebuffer-usage/src/main/java/com/idrsolutions/microservice/utils/DefaultFileServlet.java#L684)), but not the other. I have updated so that both use try-with-resources fully. 