### PR TITLE
Add support for gzip encoded streams

### DIFF
--- a/src/main/java/com/idrsolutions/microservice/utils/DownloadHelper.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/DownloadHelper.java
@@ -18,8 +18,10 @@ package com.idrsolutions.microservice.utils;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.zip.GZIPInputStream;
 import javax.naming.SizeLimitExceededException;
 
 /**
@@ -41,7 +43,16 @@ public class DownloadHelper {
         final int bufferSize = 1024;
 
         final URL url = new URL(strUrl);
-        final BufferedInputStream input = new BufferedInputStream(url.openStream());
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+
+        con.setRequestProperty("Accept-Encoding", "gzip");
+
+        final BufferedInputStream input = new BufferedInputStream(
+                "gzip".equals(con.getContentEncoding())
+                    ? new GZIPInputStream(con.getInputStream())
+                    : con.getInputStream()
+        );
+
         final ByteArrayOutputStream data = new ByteArrayOutputStream();
 
         final byte[] buffer = new byte[bufferSize];


### PR DESCRIPTION
Handled cases where the content is gzip encoded.

I've also set it up to use GZip if it's available by default.