### PR TITLE
Re-add fix for UserInstallation for Windows compatibility

### DIFF
--- a/src/main/java/com/idrsolutions/microservice/utils/LibreOfficeHelper.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/LibreOfficeHelper.java
@@ -54,7 +54,7 @@ public class LibreOfficeHelper {
         final String uniqueLOProfile = TEMP_DIR.replace('\\', '/') + "LO-" + uuid;
 
         final ProcessBuilder pb = new ProcessBuilder(sofficePath,
-                "-env:UserInstallation=file://" + uniqueLOProfile,
+                "-env:UserInstallation=file:///" + uniqueLOProfile + '/',
                 "--headless", "--convert-to", "pdf", file.getName());
 
         pb.directory(new File(file.getParent()));


### PR DESCRIPTION
Re-implement the UserInstallation part of the Windows compatibility fix for running LibreOffice that was lost when moving functionality into LibreOfficeHelper. (The code this fix is based off can be seen at https://github.com/idrsolutions/buildvu-microservice-example/pull/33/files).