### PR TITLE
Feature/new property to limit file path length

### DIFF
--- a/src/main/java/com/idrsolutions/microservice/BaseServlet.java
+++ b/src/main/java/com/idrsolutions/microservice/BaseServlet.java
@@ -30,7 +30,6 @@ import javax.json.JsonObjectBuilder;
 import javax.json.stream.JsonParser;
 import javax.json.stream.JsonParsingException;
 import javax.naming.SizeLimitExceededException;
-import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -310,12 +309,10 @@ public abstract class BaseServlet extends HttpServlet {
     /**
      * Cap the filename to fit the specified file path limit.
      * @param fileName name of the file uploaded
-     * @param context the ServletContext with access to the properties object
+     * @param filePathLimit the maximum file path length before it is capped
      * @return String representing the filename beyond a given point removed to keep files within the file path limit
      */
-    private static String capFileName(final String fileName, final ServletContext context) {
-        final Properties properties = (Properties) context.getAttribute(BaseServletContextListener.KEY_PROPERTIES);
-        final int filePathLimit = Integer.parseInt(properties.getProperty(BaseServletContextListener.KEY_PROPERTY_INTERNAL_FILENAME_LIMIT));
+    private static String capFileName(final String fileName, final int filePathLimit) {
 
         final String ext = fileName.substring(fileName.lastIndexOf(".") + 1);
         String fileNameWithoutExt = fileName.substring(0, fileName.lastIndexOf("."));
@@ -579,7 +576,10 @@ public abstract class BaseServlet extends HttpServlet {
 
         final File inputDir = createInputDirectory(uuid);
 
-        final String cappedFileName = capFileName(filename, getServletContext());
+        final Properties properties = (Properties) getServletContext().getAttribute(BaseServletContextListener.KEY_PROPERTIES);
+        final int filePathLimit = Integer.parseInt(properties.getProperty(BaseServletContextListener.KEY_PROPERTY_INTERNAL_FILENAME_LIMIT));
+
+        final String cappedFileName = capFileName(filename, filePathLimit);
 
         final File inputFile = new File(inputDir, sanitizeFileName(cappedFileName));
 

--- a/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
+++ b/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
@@ -164,10 +164,14 @@ public abstract class BaseServletContextListener implements ServletContextListen
         }
 
         final int iFilePathLimit = Integer.parseInt(properties.getProperty(BaseServletContextListener.KEY_PROPERTY_FILEPATH_LIMIT));
-        final int outputPath = properties.getProperty(KEY_PROPERTY_OUTPUT_PATH).length();
-        final int inputPath = properties.getProperty(KEY_PROPERTY_INPUT_PATH).length();
+        final int previewLength = 19;
+        final int uuidLength = 37;
+        final int outputPath = properties.getProperty(KEY_PROPERTY_OUTPUT_PATH).length() + uuidLength + previewLength;
+        final int inputPath = properties.getProperty(KEY_PROPERTY_INPUT_PATH).length() + uuidLength;
+
         final int longestPath = Math.max(outputPath, inputPath);
-        final int filenameCap = iFilePathLimit - 19 - 37 - longestPath;
+
+        final int filenameCap = iFilePathLimit - longestPath;
         if (filenameCap < 1) {
             final String message = "The \"filePathLimit\" must be large enough to cover the longest of the \"inputPath\"/\"outputPath\" (" + longestPath + "), uuid (37), preview output (19), and the filename (at least 1). The value must be at least " + (longestPath + 37 + 19 + 1) + ", but 250 is recommended for compatibility across platforms.";
             LOG.log(Level.WARNING, message);

--- a/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
+++ b/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
@@ -173,7 +173,7 @@ public abstract class BaseServletContextListener implements ServletContextListen
 
         final int filenameCap = iFilePathLimit - longestPath;
         if (filenameCap < 1) {
-            final String message = "The \"filePathLimit\" must be large enough to cover the longest of the \"inputPath\"/\"outputPath\" (" + longestPath + "), uuid (37), preview output (19), and the filename (at least 1). The value must be at least " + (longestPath + 37 + 19 + 1) + ", but 250 is recommended for compatibility across platforms.";
+            final String message = "The \"filePathLimit\" must be large enough to cover the longest of the \"inputPath\"/\"outputPath\" (" + longestPath + "), uuid (" + uuidLength + "), preview output (" + previewLength + "), and the filename (at least 1). The value must be at least " + (longestPath + uuidLength + previewLength + 1) + ", but 250 is recommended for compatibility across platforms.";
             LOG.log(Level.SEVERE, message);
             throw new IllegalArgumentException(message);
         } else {
@@ -230,7 +230,7 @@ public abstract class BaseServletContextListener implements ServletContextListen
     private void validateOutputPath(final Properties properties) {
         final String outputPath = properties.getProperty(KEY_PROPERTY_OUTPUT_PATH);
         if (outputPath == null || outputPath.isEmpty()) {
-            final String outputDir = getConfigPath() + "output/";
+            final String outputDir = getConfigPath() + "output";
             properties.setProperty(KEY_PROPERTY_OUTPUT_PATH, outputDir);
             final String message = String.format("Properties value for \"outputPath\" was not set. Using a value of \"%s\"", outputDir);
             LOG.log(Level.WARNING, message);

--- a/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
+++ b/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
@@ -174,7 +174,7 @@ public abstract class BaseServletContextListener implements ServletContextListen
         final int filenameCap = iFilePathLimit - longestPath;
         if (filenameCap < 1) {
             final String message = "The \"filePathLimit\" must be large enough to cover the longest of the \"inputPath\"/\"outputPath\" (" + longestPath + "), uuid (37), preview output (19), and the filename (at least 1). The value must be at least " + (longestPath + 37 + 19 + 1) + ", but 250 is recommended for compatibility across platforms.";
-            LOG.log(Level.WARNING, message);
+            LOG.log(Level.SEVERE, message);
             throw new IllegalArgumentException(message);
         } else {
             properties.setProperty(KEY_PROPERTY_INTERNAL_FILENAME_LIMIT, Integer.toString(filenameCap));


### PR DESCRIPTION
Functionality to limit file path length in microservice.

This will take the input and output directory lengths (accounting for UUID and Preview where applicable) and compare it to the file path limit.
If the file path limit is too small the microservice fails to start with a SERERE message and exception.
Otherwise it sets an internal properties that hold the max length of a filename.

When we would sanitise the input filename we also cap the filename based on this value.

The default value is set to 250 for several reasons, the most important are,

- The maze filename on some systems are 255 and the max file path on Windows is 260.
- By setting to 250 this gives us a buffer where the preview can expand allowing for expansion into more pages that the PDF can support and more images, shades and other content than we are ever likely to see on a single page (for instance 1,000,000,000 images, 10,000,000 shades ...).
- In the inputPath is the longest this allows for the file extension