### PR TITLE
Bug/nfs files not deleted correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.idrsolutions</groupId>
     <artifactId>base-microservice-example</artifactId>
     <packaging>jar</packaging>
-    <version>10.1.0</version>
+    <version>10.1.1</version>
     <name>IDRsolutions Base Microservice Example</name>
     <description>Provides the shared classes used by IDRsolutions microservice examples.</description>
     <url>https://github.com/idrsolutions/base-microservice-example</url>

--- a/src/main/java/com/idrsolutions/microservice/utils/FileDeletionService.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/FileDeletionService.java
@@ -54,13 +54,18 @@ public class FileDeletionService {
 
                 final long timeToDelete = currentTime - fileLifeSpan;
                 for (final String dir : dirs) {
-                    final File fileDir = new File(dir);
-                    final File[] files = fileDir.listFiles();
+                    try {
+                        final File fileDir = new File(dir);
+                        final File[] files = fileDir.listFiles();
 
-                    if (fileDir.exists() && files != null) {
-                        Arrays.stream(files)
-                                .filter(file -> file.lastModified() < timeToDelete)
-                                .forEach(FileDeletionService::deleteFile);
+                        if (fileDir.exists() && files != null) {
+                            Arrays.stream(files)
+                                    .filter(file -> file.lastModified() < timeToDelete)
+                                    .forEach(FileDeletionService::deleteFile);
+                        }
+                    } catch (final Throwable e) {
+                        final String message = String.format("Exception thrown whilst FileDeletionService was scanning (%s)", dir);
+                        LOG.log(Level.WARNING, message, e);
                     }
                 }
             }
@@ -86,7 +91,7 @@ public class FileDeletionService {
                             LOG.log(Level.WARNING, message, e);
                         }
                     });
-        } catch (final IOException e) {
+        } catch (final Throwable e) {
             final String message = String.format("Exception thrown when trying to delete file (%s)", file.getAbsolutePath());
             LOG.log(Level.WARNING, message, e);
         }


### PR DESCRIPTION
Changes are to allow the following in the File Deletion Service.

1. RuntimeExceptions will cause the file deletion to stop triggering which can happen due to SecurityManagers.
Catch is updated to catch the exception and prevent the service from closing.

2. Get the newest lastModified date from within the directory as on some systems (Linux included) this value is not updated for all changes in subdirectories.

3. Check that a conversion has actually finished, whilst the above point should prevent deletion while a conversion is still updating, this check will allow for long page conversion times.

This will help prevent some of the issues reported with this service on NFS issues (behaviour shows undeletable nfs files if deletion takes place mid-conversion).