### PR TITLE
Ensure file deletion surface can delete output with error status and …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.idrsolutions</groupId>
     <artifactId>base-microservice-example</artifactId>
     <packaging>jar</packaging>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <name>IDRsolutions Base Microservice Example</name>
     <description>Provides the shared classes used by IDRsolutions microservice examples.</description>
     <url>https://github.com/idrsolutions/base-microservice-example</url>

--- a/src/main/java/com/idrsolutions/microservice/utils/FileDeletionService.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/FileDeletionService.java
@@ -72,7 +72,9 @@ public class FileDeletionService {
                                         final String uuidFromFileName = file.getName();
                                         try {
                                             final Map<String, String> status = DBHandler.getInstance().getStatus(uuidFromFileName);
-                                            return status == null || "processed".equals(status.get("state"));
+                                            return status == null
+                                                    || "processed".equals(status.get("state"))
+                                                    || "error".equals(status.get("state"));
                                         } catch (SQLException e) {
                                             final String message = String.format("Error finding status for conversion (%s)", uuidFromFileName);
                                             LOG.log(Level.WARNING, message, e);

--- a/src/main/java/com/idrsolutions/microservice/utils/ProcessUtils.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/ProcessUtils.java
@@ -58,7 +58,7 @@ public class ProcessUtils {
                 while (run.getValue()) {
                     try {
                         final String line = outRead.readLine();
-                        if (line != null) {
+                        if (line != null && !line.startsWith("NOTE: Picked up JDK_JAVA_OPTIONS:")) {
                             LOG.log(Level.SEVERE, line);
                         } else {
                             break;


### PR DESCRIPTION
Allow File deletion service to clear conversions that returned an error
Hide module related output from child process to clean up log file