### PR TITLE
Feature/improve rmi and shutdown implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.idrsolutions</groupId>
     <artifactId>base-microservice-example</artifactId>
     <packaging>jar</packaging>
-    <version>11.0.1</version>
+    <version>12.0.0</version>
     <name>IDRsolutions Base Microservice Example</name>
     <description>Provides the shared classes used by IDRsolutions microservice examples.</description>
     <url>https://github.com/idrsolutions/base-microservice-example</url>

--- a/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
+++ b/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
@@ -60,7 +60,6 @@ public abstract class BaseServletContextListener implements ServletContextListen
     public static final String KEY_PROPERTY_FILE_DELETION_SERVICE = "fileDeletionService";
     public static final String KEY_PROPERTY_FILE_DELETION_SERVICE_FREQUENCY = "fileDeletionService.frequency";
     public static final String KEY_PROPERTY_MAX_CONVERSION_DURATION = "maxConversionDuration";
-    public static final String KEY_PROPERTY_REMOTE_TRACKING_REGISTRY = "remoteTrackingRegistry";
     public static final String KEY_PROPERTY_REMOTE_TRACKING_PORT = "remoteTracker.port";
     public static final String KEY_PROPERTY_CONVERSION_MEMORY = "conversionMemoryLimit";
 
@@ -143,7 +142,7 @@ public abstract class BaseServletContextListener implements ServletContextListen
         try {
             LOG.log(Level.INFO, "Creating RMI registry on port " + remoteTrackingPort);
             final Registry registry = LocateRegistry.createRegistry(Integer.parseInt(remoteTrackingPort));
-            propertiesFile.put(KEY_PROPERTY_REMOTE_TRACKING_REGISTRY, registry);
+            servletContext.setAttribute("com.idrsolutions.remoteTracker.registry", registry);
             registry.bind("com.idrsolutions.remoteTracker.stub", new ProgressTracker(Integer.parseInt(remoteTrackingPort)));
         } catch (final RemoteException | AlreadyBoundException e) {
             LOG.log(Level.SEVERE, "Unable to create Registry to allow conversion tracking.", e);
@@ -189,8 +188,7 @@ public abstract class BaseServletContextListener implements ServletContextListen
         }
 
         LOG.log(Level.INFO, "Shutting down RMI registry");
-        final Properties propertiesFile = (Properties) servletContextEvent.getServletContext().getAttribute(KEY_PROPERTIES);
-        final Registry registry = ((Registry) propertiesFile.get(KEY_PROPERTY_REMOTE_TRACKING_REGISTRY));
+        final Registry registry = (Registry) servletContext.getAttribute("com.idrsolutions.remoteTracker.registry");
         if (registry != null) {
             try {
                 final Remote stub = registry.lookup("com.idrsolutions.remoteTracker.stub");

--- a/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
+++ b/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
@@ -126,6 +126,9 @@ public abstract class BaseServletContextListener implements ServletContextListen
         BaseServlet.setOutputPath(propertiesFile.getProperty(KEY_PROPERTY_OUTPUT_PATH));
         BaseServlet.setIndividualTTL(Long.parseLong(propertiesFile.getProperty(KEY_PROPERTY_INDIVIDUAL_TTL)));
 
+        DBHandler.setDatabaseJNDIName(propertiesFile.getProperty(KEY_PROPERTY_DATABASE_JNDI_NAME));
+        DBHandler.initialise();
+
         if (Boolean.parseBoolean(propertiesFile.getProperty(KEY_PROPERTY_FILE_DELETION_SERVICE))) {
             servletContext.setAttribute(KEY_PROPERTY_FILE_DELETION_SERVICE, new FileDeletionService(
                     new String[]{
@@ -135,9 +138,6 @@ public abstract class BaseServletContextListener implements ServletContextListen
                     Long.parseLong(propertiesFile.getProperty(KEY_PROPERTY_FILE_DELETION_SERVICE_FREQUENCY))
             ));
         }
-
-        DBHandler.setDatabaseJNDIName(propertiesFile.getProperty(KEY_PROPERTY_DATABASE_JNDI_NAME));
-        DBHandler.initialise();
 
         final String remoteTrackingPort = propertiesFile.getProperty(KEY_PROPERTY_REMOTE_TRACKING_PORT);
         try {

--- a/src/main/java/com/idrsolutions/microservice/utils/FileDeletionService.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/FileDeletionService.java
@@ -175,4 +175,16 @@ public class FileDeletionService {
         return scheduledExecutorService.shutdownNow();
     }
 
+    /**
+     * Awaits termination of the FileDeletionService.
+     *
+     * @param timeout the maximum time to wait
+     * @param timeUnit the time unit of the timeout argument
+     * @return true if this executor terminated and false if the timeout elapsed before termination
+     * @throws InterruptedException if interrupted while waiting
+     */
+    public boolean awaitTermination(final long timeout, final TimeUnit timeUnit) throws InterruptedException {
+        return scheduledExecutorService.awaitTermination(timeout, timeUnit);
+    }
+
 }

--- a/src/main/java/com/idrsolutions/microservice/utils/ProgressTracker.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/ProgressTracker.java
@@ -1,0 +1,19 @@
+package com.idrsolutions.microservice.utils;
+
+import com.idrsolutions.microservice.db.DBHandler;
+import org.jpedal.external.RemoteTracker;
+
+import java.rmi.RemoteException;
+import java.rmi.server.UnicastRemoteObject;
+
+public class ProgressTracker extends UnicastRemoteObject implements RemoteTracker {
+
+    public ProgressTracker(int port) throws RemoteException {
+        super(port);
+    }
+
+    @Override
+    public void finishedPageDecoding(String uuid, int rawPage) {
+        DBHandler.getInstance().setCustomValue(uuid, "pagesConverted", String.valueOf(rawPage));
+    }
+}

--- a/src/main/java/com/idrsolutions/microservice/utils/ProgressTracker.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/ProgressTracker.java
@@ -8,12 +8,12 @@ import java.rmi.server.UnicastRemoteObject;
 
 public class ProgressTracker extends UnicastRemoteObject implements RemoteTracker {
 
-    public ProgressTracker(int port) throws RemoteException {
+    public ProgressTracker(final int port) throws RemoteException {
         super(port);
     }
 
     @Override
-    public void finishedPageDecoding(String uuid, int rawPage) {
+    public void finishedPageDecoding(final String uuid, final int rawPage) {
         DBHandler.getInstance().setCustomValue(uuid, "pagesConverted", String.valueOf(rawPage));
     }
 }

--- a/src/main/java/org/jpedal/external/RemoteTracker.java
+++ b/src/main/java/org/jpedal/external/RemoteTracker.java
@@ -1,0 +1,15 @@
+package org.jpedal.external;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+
+
+/**
+ * The RemoteTracker interface allows monitoring of page decode progress from another application using java RMI.
+ */
+@SuppressWarnings("ALL")
+public interface RemoteTracker extends Remote {
+
+    void finishedPageDecoding(final String uuid, final int rawPage) throws RemoteException;
+
+}


### PR DESCRIPTION
As discussed:
- Resolve RMI shutdown issue
- Resolve Tomcat cleanup race
- Init/destroy RMI in base-microservice
- Init FileDeletionService after database
- Move registry from properties file to context attribute
- Single shared ProgressTracker instance
- Tidy ProcessUtils
- Changed RMI keys from `org.jpedal` to `com.idrsolutions` (& `id` to `uuid`)

If you have started implementing RMI on a child microservice then this will allow you to tidy things up like so:
https://github.com/idrsolutions/buildvu-microservice-example/commit/16ea2b5214a41c67e29dfdab2b1eb729c3d9036b