### PR TITLE
Fix the JSON parser not handling decimal numbers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.idrsolutions</groupId>
     <artifactId>base-microservice-example</artifactId>
     <packaging>jar</packaging>
-    <version>12.0.1</version>
+    <version>12.0.2</version>
     <name>IDRsolutions Base Microservice Example</name>
     <description>Provides the shared classes used by IDRsolutions microservice examples.</description>
     <url>https://github.com/idrsolutions/base-microservice-example</url>

--- a/src/main/java/com/idrsolutions/microservice/BaseServlet.java
+++ b/src/main/java/com/idrsolutions/microservice/BaseServlet.java
@@ -743,7 +743,11 @@ public abstract class BaseServlet extends HttpServlet {
                         break;
                     case VALUE_NUMBER:
                         if (currentKey != null && arrayDepth < 1) {
-                            out.put(currentKey, String.valueOf(jp.getInt()));
+                            if (jp.isIntegralNumber()) {
+                                out.put(currentKey, String.valueOf(jp.getInt()));
+                            } else {
+                                out.put(currentKey, jp.getBigDecimal().toString());
+                            }
                         }
                         break;
                     case VALUE_TRUE:


### PR DESCRIPTION
When the JSON value was VALUE_NUMBER. It was always processed it as an Int. 
Use JsonParser's isIntegralNumber check to see if the value is a decimal or not and handle it as a BigDecimal instead.