### PR TITLE
Rename incoming files by uuid to prevent rejection edge cases (#67)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.idrsolutions</groupId>
     <artifactId>base-microservice-example</artifactId>
     <packaging>jar</packaging>
-    <version>12.0.2</version>
+    <version>13.0.0</version>
     <name>IDRsolutions Base Microservice Example</name>
     <description>Provides the shared classes used by IDRsolutions microservice examples.</description>
     <url>https://github.com/idrsolutions/base-microservice-example</url>

--- a/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
+++ b/src/main/java/com/idrsolutions/microservice/BaseServletContextListener.java
@@ -123,6 +123,17 @@ public abstract class BaseServletContextListener implements ServletContextListen
 
         BaseServlet.setInputPath(propertiesFile.getProperty(KEY_PROPERTY_INPUT_PATH));
         BaseServlet.setOutputPath(propertiesFile.getProperty(KEY_PROPERTY_OUTPUT_PATH));
+
+        final File inputDir = new File(BaseServlet.getInputPath());
+        if (!inputDir.exists() && !inputDir.mkdirs()) {
+            LOG.log(Level.SEVERE, "Unable to create input directory: " + inputDir.getAbsolutePath());
+        }
+
+        final File outputDir = new File(BaseServlet.getOutputPath());
+        if (!outputDir.exists() && !outputDir.mkdirs()) {
+            LOG.log(Level.SEVERE, "Unable to create output directory: " + outputDir.getAbsolutePath());
+        }
+
         BaseServlet.setIndividualTTL(Long.parseLong(propertiesFile.getProperty(KEY_PROPERTY_INDIVIDUAL_TTL)));
 
         DBHandler.setDatabaseJNDIName(propertiesFile.getProperty(KEY_PROPERTY_DATABASE_JNDI_NAME));

--- a/src/main/java/com/idrsolutions/microservice/utils/LibreOfficeHelper.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/LibreOfficeHelper.java
@@ -19,11 +19,9 @@
 package com.idrsolutions.microservice.utils;
 
 import java.io.File;
-import java.util.logging.Logger;
 
 public class LibreOfficeHelper {
 
-    private static final Logger LOG = Logger.getLogger(LibreOfficeHelper.class.getName());
     private static final String TEMP_DIR;
 
     static {
@@ -68,13 +66,4 @@ public class LibreOfficeHelper {
         return result;
     }
 
-    private static String getFileSizeAsString(final long fileSize) {
-        if (fileSize < 1_000) {
-            return fileSize + " bytes";
-        } else if (fileSize < 1_000_000) {
-            return String.format("%.2f KB", (fileSize / 1_000f));
-        } else {
-            return String.format("%.2f MB", (fileSize / 1_000_000f));
-        }
-    }
 }


### PR DESCRIPTION
Update file storage strategy to name files by the uuid of the conversion rather than using their original filename. This prevents edge cases where certain filenames would otherwise need to be rejected. Also includes some code tidying in other classes. Increment major version number.

---------