### PR TITLE
Make the output location of converted office documents configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.idrsolutions</groupId>
     <artifactId>base-microservice-example</artifactId>
     <packaging>jar</packaging>
-    <version>14.0.1</version>
+    <version>14.1.0</version>
     <name>IDRsolutions Base Microservice Example</name>
     <description>Provides the shared classes used by IDRsolutions microservice examples.</description>
     <url>https://github.com/idrsolutions/base-microservice-example</url>

--- a/src/main/java/com/idrsolutions/microservice/utils/LibreOfficeHelper.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/LibreOfficeHelper.java
@@ -39,7 +39,8 @@ public class LibreOfficeHelper {
      * @param file The office file to convert to PDF
      * @param uuid The uuid of the conversion on which to set the error if one occurs
      * @return true on success, false on failure
-     * @deprecated Use {@link #convertDocToPDF(String, File, String, long)} instead
+     * @deprecated Use {@link #convertDocToPDF(String, File, String, long)} or
+     *             {@link #convertDocToPDF(String, File, String, long, File)} instead
      */
     @Deprecated(forRemoval = true)
     public static boolean convertToPDF(final String sofficePath, final File file, final String uuid) {

--- a/src/main/java/com/idrsolutions/microservice/utils/LibreOfficeHelper.java
+++ b/src/main/java/com/idrsolutions/microservice/utils/LibreOfficeHelper.java
@@ -39,7 +39,9 @@ public class LibreOfficeHelper {
      * @param file The office file to convert to PDF
      * @param uuid The uuid of the conversion on which to set the error if one occurs
      * @return true on success, false on failure
+     * @deprecated Use {@link #convertDocToPDF(String, File, String, long)} instead
      */
+    @Deprecated(forRemoval = true)
     public static boolean convertToPDF(final String sofficePath, final File file, final String uuid) {
         return convertDocToPDF(sofficePath, file, uuid, 60000) == ProcessUtils.Result.SUCCESS;
     }
@@ -50,14 +52,32 @@ public class LibreOfficeHelper {
      * @param sofficePath The path to the soffice executable
      * @param file The office file to convert to PDF
      * @param uuid The uuid of the conversion on which to set the error if one occurs
+     * @param timeoutDuration The timeout duration in milliseconds for the conversion to complete before it is cancelled
      * @return Result enum value depending on the conversion result
      */
     public static ProcessUtils.Result convertDocToPDF(final String sofficePath, final File file, final String uuid, final long timeoutDuration) {
+        return convertDocToPDF(sofficePath, file, uuid, timeoutDuration, file.getParentFile());
+    }
+
+    /**
+     * Converts an office file to PDF using the specified LibreOffice executable.
+     *
+     * @param sofficePath The path to the soffice executable
+     * @param file The office file to convert to PDF
+     * @param uuid The uuid of the conversion on which to set the error if one occurs
+     * @param timeoutDuration The timeout duration in milliseconds for the conversion to complete before it is cancelled
+     * @param outputDir The directory to save the converted file to
+     * @return Result enum value depending on the conversion result
+     */
+    public static ProcessUtils.Result convertDocToPDF(final String sofficePath, final File file, final String uuid, final long timeoutDuration, final File outputDir) {
         final String uniqueLOProfile = TEMP_DIR.replace('\\', '/') + "LO-" + uuid;
 
-        final String[] commandAndArgs = new String[] {sofficePath,
+        final String[] commandAndArgs = new String[] {
+                sofficePath,
                 "-env:UserInstallation=file:///" + uniqueLOProfile,
-                "--headless", "--convert-to", "pdf", file.getName()};
+                "--headless", "--convert-to", "pdf", file.getName(),
+                "--outdir", outputDir.getAbsolutePath()
+        };
 
         final ProcessUtils.Result result =  ProcessUtils.runProcess(commandAndArgs, file.getParentFile(), uuid, "LibreOfficeConversion", timeoutDuration);
 


### PR DESCRIPTION
Adds the ability to configure where LibreOffice puts the generated PDF. Deprecates for removal an old method.